### PR TITLE
Suggestions for functional options

### DIFF
--- a/cmd/godocapiclient/main.go
+++ b/cmd/godocapiclient/main.go
@@ -11,7 +11,11 @@ import (
 func main() {
 
 	log.Println("+++++++++ SHELL CLIENT +++++++++")
-	service, _ := godocapi.NewCommandService(&shell.CommandService{})
+	// We could use the short := assignment here and skip the explicit type, but
+	// then we'd have to use separate variables for the shell and HTTP services.
+	// That's probably better, but I've gone with this approach to minimize
+	// changes.
+	var service godocapi.CommandService = &shell.CommandService{}
 
 	res, err := service.GetSource("net/http")
 
@@ -22,12 +26,11 @@ func main() {
 	log.Printf("\n--- Output ---\n> Command: %s, \n> Source: \n----- Start -----\n%s\n----- Shell End -----\n",
 		res.Command, res.Output)
 
-
 	log.Println("+++++++++ HTTP CLIENT +++++++++")
-	service, _ = godocapi.NewCommandService(&http.CommandService{},
+	service = http.New(
 		http.SetAgent("go-client/1.0"),
 		http.SetBaseUrl("localhost:8080"),
-		http.SetHttpClient(nil) )
+	)
 	res2, err2 := service.GetSource("net")
 
 	if err2 != nil {

--- a/godocapi.go
+++ b/godocapi.go
@@ -9,10 +9,3 @@ type CommandResults struct {
 type CommandService interface {
 	GetSource(arg string) (*CommandResults, error)
 }
-
-func NewCommandService(initial CommandService, options ...func(CommandService)) (CommandService, error) {
-	for _, option := range options {
-		option(initial)
-	}
-	return initial, nil
-}

--- a/http/command_service.go
+++ b/http/command_service.go
@@ -9,24 +9,36 @@ import (
 	"github.com/timbogit/godocapi"
 )
 
-
 // CommandService represents a service for managing commands.
 type CommandService struct {
-	BaseURL   *url.URL
-	UserAgent string
+	// Keep these unexported! Part of the goal of functional options is to let
+	// users configure these details without exporting the struct fields.
+	baseURL   *url.URL
+	userAgent string
 
 	httpClient *http.Client
 }
 
+func New(opts ...Option) *CommandService {
+	s := &CommandService{
+		baseURL:    &url.URL{Scheme: "http", Host: ":80"}, // reasonable default
+		httpClient: http.DefaultClient,
+	}
+	for _, o := range opts {
+		o.apply(s)
+	}
+	return s
+}
+
 func (s *CommandService) GetSource(arg string) (*godocapi.CommandResults, error) {
 	rel := &url.URL{Path: fmt.Sprintf("/godoc/src/%s", arg)}
-	u := s.BaseURL.ResolveReference(rel)
+	u := s.baseURL.ResolveReference(rel)
 	req, err := http.NewRequest("GET", u.String(), nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	req.Header.Set("User-Agent", s.UserAgent)
+	req.Header.Set("User-Agent", s.userAgent)
 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {

--- a/http/options.go
+++ b/http/options.go
@@ -3,29 +3,44 @@ package http
 import (
 	"net/http"
 	"net/url"
-
-	"github.com/timbogit/godocapi"
 )
 
-
-func SetBaseUrl(host string) func(godocapi.CommandService) {
-	return func(service godocapi.CommandService) {
-		service.(*CommandService).BaseURL = &url.URL{Scheme: "http", Host: host}
-	}
+type Option interface {
+	// Keeping this unexported makes it completely opaque to the user, which
+	// means that you can change it later.
+	apply(*CommandService)
 }
 
-func SetAgent(agent string) func(godocapi.CommandService) {
-	return func(service godocapi.CommandService) {
-		service.(*CommandService).UserAgent = agent
-	}
+// This is an idiomatic bit of Go trickery - functions can have methods! The
+// standard library's http.HandlerFunc is the most common example. Now we have
+// a small adapter that makes it easy for us to turn anonymous functions into
+// Options.
+type optionFunc func(*CommandService)
+
+func (f optionFunc) apply(s *CommandService) { f(s) }
+
+func SetBaseUrl(host string) Option {
+	return optionFunc(func(service *CommandService) {
+		service.baseURL = &url.URL{Scheme: "http", Host: host}
+	})
 }
 
-func SetHttpClient(c *http.Client) func(godocapi.CommandService) {
-	return func(service godocapi.CommandService) {
-		if c != nil {
-			service.(*CommandService).httpClient = c
-		} else {
-			service.(*CommandService).httpClient = http.DefaultClient
-		}
-	}
+func SetAgent(agent string) Option {
+	return optionFunc(func(service *CommandService) {
+		service.userAgent = agent
+	})
+}
+
+func SetHttpClient(c *http.Client) Option {
+	return optionFunc(func(service *CommandService) {
+		// Options typically don't contain the logic to fall back to the default
+		// HTTP client if the user passes a nil - part of the point of this
+		// pattern is to avoid explicitly passing nil to trigger the default
+		// behavior. Instead, move that logic into the constructor.
+		//
+		// If the user explicitly passes a nil here, it's perfectly fine to panic
+		// later on with a nil pointer dereference - idiomatic Go code doesn't
+		// contort itself to protect users from themselves.
+		service.httpClient = http.DefaultClient
+	})
 }


### PR DESCRIPTION
You're 90% of the way there with the functional options that you already have!

You went ever so slightly wrong when you put the `NewCommandService` constructor with the *interface* instead of the *implementing structs*. When you're planning to have multiple packages implement a common interface, put the constructor functions with the implementations, not with the abstract interface. This makes functional options much simpler, since each implementation will take different options: in this case, it doesn't make much sense to set a URL for the shell client.

I've left some other notes as comments, but they're just elaborations on the main point above.

Nice work, though! This project looks like it's coming along well.